### PR TITLE
Use userId from authentication result to avoid userId inconsistent issue

### DIFF
--- a/www/AuthenticationResult.js
+++ b/www/AuthenticationResult.js
@@ -27,6 +27,8 @@ function AuthenticationResult(authResult) {
     if (!this.userInfo) {
         this.userInfo = new UserInfo(authResult.userInfo);
     }
+
+    this.userInfo.userId = authResult.userInfo.userId;
 }
 
 /**


### PR DESCRIPTION
Use userId from authentication result to avoid userId inconsistent issue.
userId parsed from accessToken is different from the userId from idToken and authResult